### PR TITLE
Move set construction from predicate methods to constants to optimize

### DIFF
--- a/demobundle/src/main/java/danta/aemdemo/contextprocessors/TemplateContextProcessor.java
+++ b/demobundle/src/main/java/danta/aemdemo/contextprocessors/TemplateContextProcessor.java
@@ -10,6 +10,8 @@ import org.apache.felix.scr.annotations.Service;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ValueMap;
+
+import java.util.Collections;
 import java.util.Set;
 
 import static danta.Constants.*;
@@ -20,9 +22,11 @@ import static danta.aem.Constants.*;
 public class TemplateContextProcessor
         extends AbstractCheckComponentCategoryContextProcessor<TemplateContentModel> {
 
+    private static final Set<String> ANY_OF = Collections.unmodifiableSet(Sets.newHashSet("dantaaemdemo"));
+
     @Override
     public Set<String> anyOf() {
-        return Sets.newHashSet("dantaaemdemo");
+        return ANY_OF;
     }
 
     @Override

--- a/demobundle/src/main/java/danta/aemdemo/contextprocessors/TestDantaDemoContextProcessor.java
+++ b/demobundle/src/main/java/danta/aemdemo/contextprocessors/TestDantaDemoContextProcessor.java
@@ -12,6 +12,7 @@ import org.apache.felix.scr.annotations.Service;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.ValueMap;
 
+import java.util.Collections;
 import java.util.Set;
 
 import static danta.Constants.LOW_PRIORITY;
@@ -23,9 +24,11 @@ import static danta.aem.Constants.SLING_HTTP_REQUEST;
 public class TestDantaDemoContextProcessor extends
         AbstractCheckComponentCategoryContextProcessor<ContentModel> {
 
+    private static final Set<String> ANY_OF = Collections.unmodifiableSet(Sets.newHashSet("testdanta"));
+
     @Override
     public Set<String> anyOf() {
-        return Sets.newHashSet("testdanta");
+        return ANY_OF;
     }
 
     @Override


### PR DESCRIPTION
Code optimization so these constant sets are not constructed on every single request.  The constants are wrapped in an unmodifiableSet to ensure these sets aren't changed elsewhere.

DantaFramework/AEM#3 will make the same change to the base CPs.